### PR TITLE
dcind build ci pipelines: support new docker release tag format

### DIFF
--- a/pipeline-pr.yml
+++ b/pipeline-pr.yml
@@ -13,6 +13,7 @@ resources:
   source:
     owner: moby
     repository: moby
+    tag_filter: "(?:docker-)?(?:v)?([^v].*)"
     access_token: ((ci-gh-public-repo-read-token))
 
 - name: docker-compose-release

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -24,6 +24,7 @@ resources:
   source:
     owner: moby
     repository: moby
+    tag_filter: "(?:docker-)?(?:v)?([^v].*)"
     access_token: ((ci-gh-public-repo-read-token))
 
 - name: docker-compose-release


### PR DESCRIPTION
Previously, https://github.com/moby/moby releases were tagged with 
e.g. "v28.0.0". Since 29.0.0, it seems to get tagged with e.g. 
"docker-v29.0.0". This change should support both formats.
